### PR TITLE
feat: implement meta-learning strategies for self-evolution

### DIFF
--- a/android/app/src/main/kotlin/com/heyhomie/app/core/api/HomieApiClient.kt
+++ b/android/app/src/main/kotlin/com/heyhomie/app/core/api/HomieApiClient.kt
@@ -1,0 +1,67 @@
+package com.heyhomie.app.core.api
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.withContext
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class HomieApiClient @Inject constructor() {
+    private val client = OkHttpClient.Builder().connectTimeout(10, TimeUnit.SECONDS).readTimeout(60, TimeUnit.SECONDS).build()
+    private var baseUrl: String = ""
+    fun configure(serverUrl: String) { baseUrl = serverUrl.trimEnd('/') }
+    val isConfigured: Boolean get() = baseUrl.isNotBlank()
+
+    suspend fun healthCheck(): Boolean = withContext(Dispatchers.IO) {
+        if (baseUrl.isBlank()) return@withContext false
+        try { client.newCall(Request.Builder().url("$baseUrl/health").get().build()).execute().isSuccessful }
+        catch (_: Exception) { false }
+    }
+
+    suspend fun sendMessage(message: String, conversationId: String): String = withContext(Dispatchers.IO) {
+        require(baseUrl.isNotBlank()) { "Server URL not configured" }
+        val body = JSONObject().apply { put("message", message); put("conversation_id", conversationId) }
+        val request = Request.Builder().url("$baseUrl/api/chat").addHeader("Content-Type", "application/json")
+            .post(body.toString().toRequestBody("application/json".toMediaType())).build()
+        val response = client.newCall(request).execute()
+        if (!response.isSuccessful) throw RuntimeException("Chat API error: ${response.code} ${response.message}")
+        val json = JSONObject(response.body?.string() ?: "{}")
+        json.optString("response", json.optString("message", ""))
+    }
+
+    fun streamMessages(conversationId: String): Flow<String> = callbackFlow {
+        require(baseUrl.isNotBlank()) { "Server URL not configured" }
+        val wsUrl = baseUrl.replace("http://", "ws://").replace("https://", "wss://")
+        val ws = client.newWebSocket(Request.Builder().url("$wsUrl/ws").build(), object : WebSocketListener() {
+            override fun onOpen(webSocket: WebSocket, response: Response) {
+                webSocket.send(JSONObject().apply { put("type", "subscribe"); put("conversation_id", conversationId) }.toString())
+            }
+            override fun onMessage(webSocket: WebSocket, text: String) {
+                try {
+                    val json = JSONObject(text); val chunk = json.optString("chunk", json.optString("text", ""))
+                    if (chunk.isNotEmpty()) trySend(chunk)
+                    if (json.optBoolean("done", false)) close()
+                } catch (_: Exception) { trySend(text) }
+            }
+            override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) { close(t) }
+            override fun onClosed(webSocket: WebSocket, code: Int, reason: String) { close() }
+        })
+        awaitClose { ws.close(1000, "Done") }
+    }
+
+    suspend fun getBriefing(): String = withContext(Dispatchers.IO) {
+        require(baseUrl.isNotBlank()) { "Server URL not configured" }
+        val response = client.newCall(Request.Builder().url("$baseUrl/api/briefing").get().build()).execute()
+        if (!response.isSuccessful) throw RuntimeException("Briefing API error: ${response.code}")
+        val json = JSONObject(response.body?.string() ?: "{}")
+        json.optString("briefing", json.optString("message", "No briefing available."))
+    }
+}

--- a/android/app/src/main/kotlin/com/heyhomie/app/core/api/di/ApiModule.kt
+++ b/android/app/src/main/kotlin/com/heyhomie/app/core/api/di/ApiModule.kt
@@ -1,0 +1,23 @@
+package com.heyhomie.app.core.api.di
+
+import com.heyhomie.app.core.api.HomieApiClient
+import com.heyhomie.app.core.config.SettingsStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ApiModule {
+    @Provides @Singleton
+    fun provideHomieApiClient(settings: SettingsStore): HomieApiClient {
+        val client = HomieApiClient()
+        val serverUrl = runBlocking { settings.serverUrl.first() }
+        if (serverUrl.isNotBlank()) client.configure(serverUrl)
+        return client
+    }
+}

--- a/android/app/src/main/kotlin/com/heyhomie/app/core/repository/ChatRepository.kt
+++ b/android/app/src/main/kotlin/com/heyhomie/app/core/repository/ChatRepository.kt
@@ -1,0 +1,38 @@
+package com.heyhomie.app.core.repository
+
+import com.heyhomie.app.core.api.HomieApiClient
+import com.heyhomie.app.core.data.dao.MessageDao
+import com.heyhomie.app.core.data.entity.MessageEntity
+import com.heyhomie.app.core.model.ChatMessage
+import com.heyhomie.app.core.model.MessageRole
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ChatRepository @Inject constructor(
+    private val apiClient: HomieApiClient,
+    private val messageDao: MessageDao
+) {
+    fun getMessages(conversationId: String): Flow<List<ChatMessage>> =
+        messageDao.getMessages(conversationId).map { entities -> entities.map { it.toChatMessage() } }
+    fun getConversationIds(): Flow<List<String>> = messageDao.getConversationIds()
+    suspend fun sendMessage(text: String, conversationId: String): ChatMessage {
+        messageDao.insert(MessageEntity(conversationId = conversationId, role = "user", text = text))
+        val responseText = apiClient.sendMessage(text, conversationId)
+        val entity = MessageEntity(conversationId = conversationId, role = "assistant", text = responseText)
+        messageDao.insert(entity)
+        return entity.toChatMessage()
+    }
+    fun streamMessages(conversationId: String) = apiClient.streamMessages(conversationId)
+    suspend fun getBriefing(): String = apiClient.getBriefing()
+    suspend fun saveMessage(conversationId: String, role: String, text: String) {
+        messageDao.insert(MessageEntity(conversationId = conversationId, role = role, text = text))
+    }
+}
+private fun MessageEntity.toChatMessage() = ChatMessage(
+    id = id,
+    role = when (role) { "user" -> MessageRole.USER; "assistant" -> MessageRole.ASSISTANT; else -> MessageRole.SYSTEM },
+    text = text, timestamp = timestamp
+)

--- a/android/app/src/main/kotlin/com/heyhomie/app/sync/BriefingSyncWorker.kt
+++ b/android/app/src/main/kotlin/com/heyhomie/app/sync/BriefingSyncWorker.kt
@@ -1,0 +1,52 @@
+package com.heyhomie.app.sync
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.heyhomie.app.R
+import com.heyhomie.app.core.api.HomieApiClient
+import com.heyhomie.app.core.config.SettingsStore
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.flow.first
+
+@HiltWorker
+class BriefingSyncWorker @AssistedInject constructor(
+    @Assisted private val appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val apiClient: HomieApiClient,
+    private val settingsStore: SettingsStore
+) : CoroutineWorker(appContext, workerParams) {
+    override suspend fun doWork(): Result = try {
+        if (!settingsStore.briefingEnabled.first()) return Result.success()
+        val serverUrl = settingsStore.serverUrl.first()
+        if (serverUrl.isBlank()) return Result.success()
+        apiClient.configure(serverUrl)
+        if (!apiClient.healthCheck()) return Result.retry()
+        val briefing = apiClient.getBriefing()
+        if (briefing.isNotBlank()) showNotification(briefing)
+        Result.success()
+    } catch (_: Exception) { Result.retry() }
+
+    private fun showNotification(briefing: String) {
+        val channelId = "homie_briefing"
+        (appContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
+            .createNotificationChannel(NotificationChannel(channelId, "Homie Briefings", NotificationManager.IMPORTANCE_DEFAULT))
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(appContext, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) return
+        NotificationManagerCompat.from(appContext).notify(1001,
+            NotificationCompat.Builder(appContext, channelId).setSmallIcon(R.mipmap.ic_launcher)
+                .setContentTitle("Homie Briefing").setContentText(briefing)
+                .setStyle(NotificationCompat.BigTextStyle().bigText(briefing))
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT).setAutoCancel(true).build())
+    }
+}

--- a/android/app/src/main/kotlin/com/heyhomie/app/sync/ConversationSyncWorker.kt
+++ b/android/app/src/main/kotlin/com/heyhomie/app/sync/ConversationSyncWorker.kt
@@ -1,0 +1,30 @@
+package com.heyhomie.app.sync
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.heyhomie.app.core.api.HomieApiClient
+import com.heyhomie.app.core.config.SettingsStore
+import com.heyhomie.app.core.data.dao.MessageDao
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.flow.first
+
+@HiltWorker
+class ConversationSyncWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val apiClient: HomieApiClient,
+    private val messageDao: MessageDao,
+    private val settingsStore: SettingsStore
+) : CoroutineWorker(appContext, workerParams) {
+    override suspend fun doWork(): Result = try {
+        val serverUrl = settingsStore.serverUrl.first()
+        if (serverUrl.isBlank()) Result.success()
+        else {
+            apiClient.configure(serverUrl)
+            if (!apiClient.healthCheck()) Result.retry() else Result.success()
+        }
+    } catch (_: Exception) { Result.retry() }
+}

--- a/android/app/src/main/kotlin/com/heyhomie/app/sync/SyncScheduler.kt
+++ b/android/app/src/main/kotlin/com/heyhomie/app/sync/SyncScheduler.kt
@@ -1,0 +1,28 @@
+package com.heyhomie.app.sync
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SyncScheduler @Inject constructor(@ApplicationContext private val context: Context) {
+    fun scheduleConversationSync() {
+        val c = Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build()
+        val req = PeriodicWorkRequestBuilder<ConversationSyncWorker>(15, TimeUnit.MINUTES)
+            .setConstraints(c).setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 5, TimeUnit.MINUTES).build()
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork("conversation_sync", ExistingPeriodicWorkPolicy.KEEP, req)
+    }
+    fun scheduleBriefingSync() {
+        val c = Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build()
+        val req = PeriodicWorkRequestBuilder<BriefingSyncWorker>(6, TimeUnit.HOURS).setConstraints(c).build()
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork("briefing_sync", ExistingPeriodicWorkPolicy.KEEP, req)
+    }
+}

--- a/docs/superpowers/specs/2026-04-05-sp1-make-it-work-design.md
+++ b/docs/superpowers/specs/2026-04-05-sp1-make-it-work-design.md
@@ -1,0 +1,113 @@
+# SP1: Make Homie Actually Work — Design Spec
+
+**Date:** 2026-04-05
+**Goal:** Fix all critical broken paths so Homie works reliably as a local AI assistant on Windows/Linux/Mac.
+
+---
+
+## 1. Scope
+
+Fix the 5 critical blockers that prevent Homie from being a working product:
+
+1. **LAN Backend** — Currently raises NotImplementedError. Implement real peer-to-peer model serving via mDNS discovery.
+2. **Finetune Merge** — QLoRA → merged model → GGUF pipeline is incomplete. Complete the merge and quantization flow.
+3. **Knowledge Graph** — Entity extraction and relationship inference exist but aren't wired to the brain's reasoning pipeline. Connect them.
+4. **Error Handling** — Many silent try/except blocks. Add structured logging and graceful degradation.
+5. **Test Coverage** — Integration tests exist but gaps remain. Target 80%+ on core modules.
+
+## 2. LAN Backend
+
+**File:** `src/homie_core/backend/lan.py`
+
+**Current state:** Raises `NotImplementedError`
+
+**Design:**
+- Use `zeroconf` (mDNS/DNS-SD) for automatic discovery of other Homie instances on the LAN
+- Each Homie instance advertises an OpenAI-compatible API endpoint on a random port
+- The LAN backend connects to discovered peers and routes inference requests
+- Fallback chain: local GGUF → LAN peer → cloud (Qubrid)
+- Health checks every 30s to detect peer availability
+- No authentication needed for LAN (trusted network assumption, matching existing config)
+
+**Interface:**
+```python
+class LanBackend:
+    async def discover_peers(self) -> list[PeerInfo]
+    async def generate(self, prompt, **kwargs) -> str
+    async def health_check(self) -> bool
+```
+
+## 3. Finetune Merge Pipeline
+
+**File:** `src/homie_core/finetune/training/merge.py`
+
+**Current state:** Raises `NotImplementedError("Requires model files")`
+
+**Design:**
+- Accept a base model path + LoRA adapter path
+- Merge using `peft` library's `merge_and_unload()`
+- Save merged model to temp directory
+- Quantize to GGUF using `llama.cpp`'s `convert.py` if available, or `ctransformers`
+- Update the model registry with the new merged model
+- Cleanup temp files on success
+
+**Interface:**
+```python
+class MergeEngine:
+    def merge_lora(self, base_model: str, adapter_path: str) -> str  # returns merged path
+    def quantize_gguf(self, model_path: str, quant_type: str = "Q4_K_M") -> str  # returns GGUF path
+    def merge_and_quantize(self, base_model: str, adapter_path: str) -> str  # full pipeline
+```
+
+## 4. Knowledge Graph Integration
+
+**Current state:** Entity extraction framework exists in the brain but isn't wired to reasoning.
+
+**Design:**
+- Wire entity extraction into the brain's PERCEIVE stage
+- During RETRIEVE stage, query the knowledge graph for related entities
+- During REASON stage, include graph context in the synthesis prompt
+- Store new entities/relationships after each conversation turn
+- Use existing SQLite for graph storage (simple adjacency table, no external graph DB)
+
+**Changes:**
+- `src/homie_core/brain/cogarc.py` — Add graph context to perceive/retrieve/reason stages
+- `src/homie_core/intelligence/knowledge/` — Ensure entity extractor and relationship builder are called
+
+## 5. Error Handling
+
+**Current state:** Many `except Exception: pass` or `except: log.debug()` patterns.
+
+**Design:**
+- Replace silent failures with structured logging (level-appropriate)
+- Critical paths (inference, memory, voice) get retry logic with exponential backoff
+- Non-critical paths (plugins, telemetry) get graceful degradation with user notification
+- Add a health dashboard command (`/health`) that reports component status
+- All subsystems report status to the self-healing watchdog
+
+**Scope:** Focus on the top 20 most impactful error paths, not every single try/except.
+
+## 6. Test Coverage
+
+**Target:** 80%+ on core modules (brain, memory, inference, RAG)
+
+**Design:**
+- Add unit tests for each brain stage (perceive, classify, retrieve, reason, reflect, adapt)
+- Add integration tests for inference router (mock backends)
+- Add memory system tests (write/read/consolidate/forget cycles)
+- Add RAG pipeline tests (ingest → search → retrieve)
+- Add plugin loading tests
+- Use pytest with fixtures for common setup
+
+## 7. Implementation Approach
+
+All changes are PRs to MuthuGsubramanian/Homie from this dev machine. Claude Desktop on the GPU laptop will test and apply them.
+
+**PR Strategy:**
+- PR 1: LAN Backend implementation
+- PR 2: Finetune merge pipeline
+- PR 3: Knowledge graph wiring
+- PR 4: Error handling improvements
+- PR 5: Test coverage expansion
+
+Each PR is independent and can be reviewed/merged separately.

--- a/src/homie_core/brain/cognitive_arch.py
+++ b/src/homie_core/brain/cognitive_arch.py
@@ -41,6 +41,16 @@ from homie_core.security.injection_detector import sanitize_external_content
 from homie_core.security.redact import redact_sensitive_text
 from homie_core.rag.pipeline import RagPipeline
 
+import logging
+import time as _time
+logger = logging.getLogger(__name__)
+
+try:
+    from homie_core.meta_learning import StrategySelector as _MLS, MetaPerformanceTracker as _MLP, get_strategy_by_name as _mlg
+    _META_LEARNING_AVAILABLE = True
+except ImportError:
+    _META_LEARNING_AVAILABLE = False
+
 
 # ---------------------------------------------------------------------------
 # Query complexity classification
@@ -285,6 +295,11 @@ class CognitiveArchitecture:
             semantic_memory=semantic_memory,
             episodic_memory=episodic_memory,
         )
+        self._strategy_selector = strategy_selector if _META_LEARNING_AVAILABLE else None
+        self._perf_tracker = performance_tracker if _META_LEARNING_AVAILABLE else None
+        self._auto_tuner = auto_tuner if _META_LEARNING_AVAILABLE else None
+        self._last_mo = {}
+
         # Conversation meta-tracking
         self._topic_history: list[str] = []
         self._user_engagement: float = 0.5  # 0=disengaged, 1=highly engaged
@@ -548,7 +563,7 @@ class CognitiveArchitecture:
                 used += len(project_section)
 
         # 10. Response guidance based on user state + persona
-        guidance = self._generate_response_guidance(complexity, awareness)
+        guidance = self._generate_response_guidance(complexity, awareness, meta_overrides)
         if guidance:
             parts.append(f"\n[GUIDANCE]\n{guidance}")
 
@@ -557,11 +572,39 @@ class CognitiveArchitecture:
 
         return "\n".join(parts)
 
+
+    def _select_meta_strategy(self, query, complexity):
+        if not self._strategy_selector: return {}
+        try:
+            tt = "general"; q = query.lower()
+            if any(k in q for k in ("code","function","debug","implement","class")): tt = "code_generation"
+            elif any(k in q for k in ("search","find","research","article")): tt = "research"
+            elif complexity in (QueryComplexity.TRIVIAL, QueryComplexity.SIMPLE): tt = "conversation"
+            s = self._strategy_selector.select_reasoning_strategy(tt, {"complexity": complexity})
+            if not s: return {}
+            ov = s.apply(query, {"complexity": complexity})
+            ov["_task_type"], ov["_strategy_name"] = tt, s.name
+            return ov
+        except: logger.warning("Meta strategy selection failed", exc_info=True); return {}
+
+    def _record_meta_outcome(self, query, response, duration_ms, success):
+        ov = self._last_mo
+        if not ov or not self._strategy_selector: return
+        try:
+            sn = ov.get("_strategy_name",""); so = _mlg(sn) if _META_LEARNING_AVAILABLE else None
+            if so:
+                q = min(1.0, len(response)/500.0)
+                self._strategy_selector.record_outcome(task_type=ov.get("_task_type","general"), strategy=so, success=success, metrics={"duration_ms":duration_ms,"quality":q,"satisfaction":0.5})
+            if self._perf_tracker: self._perf_tracker.record_task(task_type=ov.get("_task_type","general"), duration_ms=duration_ms, success=success, quality_score=min(1.0,len(response)/500.0), strategy_key=sn)
+            if self._auto_tuner and sn: self._auto_tuner.record_param_outcome("temperature", success)
+        except: logger.warning("Meta outcome recording failed", exc_info=True)
+
     def _generate_response_guidance(
-        self, complexity: str, awareness: SituationalAwareness
+        self, complexity: str, awareness: SituationalAwareness, meta_overrides=None,
     ) -> str:
         """Generate response style guidance based on user's cognitive state and persona."""
         hints = []
+        meta_overrides = meta_overrides or {}
 
         # Specialist persona guidance (replaces simple activity hints)
         persona_hint = get_persona_guidance(
@@ -571,8 +614,10 @@ class CognitiveArchitecture:
         if persona_hint:
             hints.append(persona_hint)
 
-        # Chain-of-thought for complex queries
-        if complexity in (QueryComplexity.COMPLEX, QueryComplexity.DEEP):
+        mg = meta_overrides.get("guidance")
+        if mg:
+            hints.append(mg)
+        elif complexity in (QueryComplexity.COMPLEX, QueryComplexity.DEEP):
             hints.append(
                 "This is a complex question. Think step by step: "
                 "1) Identify what's being asked, 2) Consider the key factors, "
@@ -698,8 +743,10 @@ class CognitiveArchitecture:
 
         adjustments = self._reflect_on_response(user_input, complexity, awareness)
         adjustments = self._hooks.emit(PipelineStage.REFLECTED, adjustments)
-        temperature = adjustments.get("temperature", budget_cfg["temperature"])
-
+        temperature = adjustments.get('temperature', meta_overrides.get('temperature', budget_cfg['temperature']))
+        if meta_overrides.get('max_tokens_factor'):
+            budget_cfg = dict(budget_cfg) if not isinstance(budget_cfg, dict) else budget_cfg
+            budget_cfg['max_tokens'] = int(budget_cfg['max_tokens'] * meta_overrides['max_tokens_factor'])
         return prompt, budget_cfg, temperature
 
     def _track_conversation_meta(self, user_input: str) -> None:
@@ -736,6 +783,7 @@ class CognitiveArchitecture:
         self._track_conversation_meta(user_input)
 
         # Stages 1-5: Perceive, Classify, Retrieve, Reason, Reflect
+        t0 = _time.monotonic()
         prompt, budget_cfg, temperature = self._prepare_prompt(user_input)
         max_tokens = budget_cfg["max_tokens"]
 

--- a/src/homie_core/meta_learning/__init__.py
+++ b/src/homie_core/meta_learning/__init__.py
@@ -1,17 +1,19 @@
-"""Homie Meta-Learning — learning how to learn better.
+"""Homie Meta-Learning -- learning how to learn better."""
 
-Optimises strategy selection, cross-domain transfer, performance tracking,
-and automatic hyperparameter tuning across every Homie subsystem.
-"""
-
-from .strategy_selector import StrategySelector
+from .strategy_selector import StrategySelector, SelectionAlgorithm, ArmRecord
+from .strategies import (
+    ReasoningStrategy, DirectPromptStrategy, ChainOfThoughtStrategy,
+    ToolAugmentedStrategy, BUILTIN_STRATEGIES, get_strategy_by_name,
+)
 from .transfer_learner import TransferLearner
 from .performance_tracker import MetaPerformanceTracker
-from .auto_tuner import AutoTuner
+from .auto_tuner import AutoTuner, BetaPrior
+from .persistence import MetaLearningStore
 
 __all__ = [
-    "StrategySelector",
-    "TransferLearner",
-    "MetaPerformanceTracker",
-    "AutoTuner",
+    "StrategySelector", "SelectionAlgorithm", "ArmRecord",
+    "ReasoningStrategy", "DirectPromptStrategy", "ChainOfThoughtStrategy",
+    "ToolAugmentedStrategy", "BUILTIN_STRATEGIES", "get_strategy_by_name",
+    "TransferLearner", "MetaPerformanceTracker", "AutoTuner", "BetaPrior",
+    "MetaLearningStore",
 ]

--- a/src/homie_core/meta_learning/auto_tuner.py
+++ b/src/homie_core/meta_learning/auto_tuner.py
@@ -1,162 +1,135 @@
 # src/homie_core/meta_learning/auto_tuner.py
-"""Auto Tuner — automatically tunes Homie's hyperparameters based on performance."""
-
+"""Bayesian-inspired hyperparameter tuning with SQLite persistence."""
 from __future__ import annotations
-
-import logging
-import time
+import logging, random, time
 from dataclasses import dataclass, field
 from typing import Any
-
 from .performance_tracker import MetaPerformanceTracker
 
 log = logging.getLogger(__name__)
 
+@dataclass
+class BetaPrior:
+    alpha: float = 1.0; beta: float = 1.0
+    @property
+    def mean(self): return self.alpha/(self.alpha+self.beta)
+    @property
+    def variance(self): a,b=self.alpha,self.beta; return (a*b)/((a+b)**2*(a+b+1))
+    @property
+    def samples(self): return int(self.alpha+self.beta-2)
+    def update(self, success):
+        if success: self.alpha += 1.0
+        else: self.beta += 1.0
+    def sample(self): return random.betavariate(max(self.alpha,0.01),max(self.beta,0.01))
+    def to_dict(self): return {"alpha":self.alpha,"beta":self.beta}
+    @classmethod
+    def from_dict(cls, d): return cls(alpha=d.get("alpha",1.0),beta=d.get("beta",1.0))
 
 @dataclass
-class _TuningRecord:
-    """History entry for an applied tuning."""
+class TunableParam:
+    name: str; value: float; min_val: float; max_val: float; step: float
+    prior: BetaPrior = field(default_factory=BetaPrior)
+    def propose_change(self):
+        belief=self.prior.sample()
+        delta=random.uniform(-self.step,self.step) if belief>0.6 else random.uniform(-3*self.step,3*self.step)
+        return max(self.min_val,min(self.max_val,round(self.value+delta,4)))
 
-    parameter: str
-    old_value: Any
-    new_value: Any
-    reason: str
-    applied_at: float
-    reverted: bool = False
+_DEFAULTS=[
+    {"name":"temperature","value":0.7,"min_val":0.1,"max_val":1.2,"step":0.05},
+    {"name":"max_tokens","value":768,"min_val":128,"max_val":4096,"step":64},
+    {"name":"context_budget","value":1.0,"min_val":0.3,"max_val":2.0,"step":0.1},
+    {"name":"explore_rate","value":0.15,"min_val":0.02,"max_val":0.40,"step":0.02},
+]
 
+@dataclass
+class _Rec:
+    parameter: str; old_value: Any; new_value: Any; reason: str
+    applied_at: float; reverted: bool = False; db_id: int|None = None
 
-# ── tuning rules ────────────────────────────────────────────────────────
-# Each rule is a callable(config, tracker) -> list[dict] | None
-
-def _rule_cache_size(config: dict, tracker: MetaPerformanceTracker) -> list[dict]:
-    """Suggest increasing cache if hit-rate is high (indicates cache is useful)."""
-    suggestions: list[dict] = []
-    cache_hit_rate = config.get("cache_hit_rate", 0.0)
-    cache_max = config.get("cache_max_entries", 500)
-    if cache_hit_rate >= 0.80 and cache_max < 5000:
-        suggestions.append(
-            {
-                "parameter": "cache_max_entries",
-                "old_value": cache_max,
-                "new_value": min(cache_max * 2, 5000),
-                "reason": f"Cache hit rate is {cache_hit_rate:.0%} — increasing capacity should help.",
-            }
-        )
-    return suggestions
-
-
-def _rule_probe_interval(config: dict, tracker: MetaPerformanceTracker) -> list[dict]:
-    """Relax probe interval when the system is healthy for a while."""
-    suggestions: list[dict] = []
-    health = tracker.get_overall_health()
-    probe_interval = config.get("probe_interval_s", 30)
-    if health.get("status") == "healthy" and probe_interval < 120:
-        suggestions.append(
-            {
-                "parameter": "probe_interval_s",
-                "old_value": probe_interval,
-                "new_value": min(probe_interval * 2, 120),
-                "reason": "System is healthy — reducing probe frequency to save resources.",
-            }
-        )
-    return suggestions
-
-
-def _rule_explore_rate(config: dict, tracker: MetaPerformanceTracker) -> list[dict]:
-    """Lower exploration when overall quality is high, raise it when struggling."""
-    suggestions: list[dict] = []
-    health = tracker.get_overall_health()
-    explore = config.get("explore_rate", 0.15)
-    sr = health.get("overall_success_rate", 0.0)
-
-    if sr >= 0.9 and explore > 0.05:
-        suggestions.append(
-            {
-                "parameter": "explore_rate",
-                "old_value": explore,
-                "new_value": max(explore * 0.5, 0.05),
-                "reason": f"Success rate is {sr:.0%} — reducing exploration to exploit winning strategies.",
-            }
-        )
-    elif sr < 0.6 and explore < 0.30:
-        suggestions.append(
-            {
-                "parameter": "explore_rate",
-                "old_value": explore,
-                "new_value": min(explore * 2, 0.30),
-                "reason": f"Success rate is {sr:.0%} — increasing exploration to find better strategies.",
-            }
-        )
-    return suggestions
-
-
-_RULES = [_rule_cache_size, _rule_probe_interval, _rule_explore_rate]
-
+def _r_cache(cfg,trk):
+    hr=cfg.get("cache_hit_rate",0.0); mx=cfg.get("cache_max_entries",500)
+    return [{"parameter":"cache_max_entries","old_value":mx,"new_value":min(mx*2,5000),"reason":f"Cache hit {hr:.0%}"}] if hr>=0.8 and mx<5000 else []
+def _r_probe(cfg,trk):
+    h=trk.get_overall_health(); iv=cfg.get("probe_interval_s",30)
+    return [{"parameter":"probe_interval_s","old_value":iv,"new_value":min(iv*2,120),"reason":"Healthy"}] if h.get("status")=="healthy" and iv<120 else []
+def _r_explore(cfg,trk):
+    sr=trk.get_overall_health().get("overall_success_rate",0.0); e=cfg.get("explore_rate",0.15)
+    if sr>=0.9 and e>0.05: return [{"parameter":"explore_rate","old_value":e,"new_value":max(e*0.5,0.05),"reason":f"SR {sr:.0%}"}]
+    if sr<0.6 and e<0.30: return [{"parameter":"explore_rate","old_value":e,"new_value":min(e*2,0.30),"reason":f"SR {sr:.0%}"}]
+    return []
 
 class AutoTuner:
-    """Automatically tunes Homie's hyperparameters."""
-
-    def __init__(self, config: dict, performance_tracker: MetaPerformanceTracker):
-        self._config = config
-        self._tracker = performance_tracker
-        self._history: list[_TuningRecord] = []
-
-    # ── public API ──────────────────────────────────────────────────────
-
-    def suggest_tunings(self) -> list[dict]:
-        """Suggest parameter changes based on current config and performance data."""
-        suggestions: list[dict] = []
-        for rule in _RULES:
+    """Bayesian-inspired hyperparameter tuner with SQLite persistence."""
+    def __init__(self, config, performance_tracker, storage=None):
+        self._config,self._tracker,self._storage=config,performance_tracker,storage
+        self._history=[]; self._params={}
+        for s in _DEFAULTS:
+            self._params[s["name"]]=TunableParam(name=s["name"],value=float(config.get(s["name"],s["value"])),
+                min_val=s["min_val"],max_val=s["max_val"],step=s["step"])
+        if storage:
             try:
-                result = rule(self._config, self._tracker)
-                if result:
-                    suggestions.extend(result)
-            except Exception:
-                log.warning("Tuning rule %s failed", rule.__name__, exc_info=True)
-        return suggestions
+                for n,d in storage.load_tuner_params().items():
+                    if n in self._params:
+                        self._params[n].value=float(d["value"])
+                        if d.get("prior"): self._params[n].prior=BetaPrior.from_dict(d["prior"])
+                        config[n]=d["value"]
+                for r in storage.load_tuner_history():
+                    self._history.append(_Rec(parameter=r["parameter"],old_value=r["old_value"],
+                        new_value=r["new_value"],reason=r["reason"],applied_at=0.0,
+                        reverted=bool(r.get("reverted",False)),db_id=r.get("id")))
+            except: pass
 
-    def apply_tuning(self, tuning: dict) -> bool:
-        """Apply a suggested tuning to the live config. Returns True on success."""
-        param = tuning.get("parameter")
-        new_val = tuning.get("new_value")
-        if not param:
-            return False
+    def suggest_tunings(self):
+        out=[]
+        for rule in [_r_cache,_r_probe,_r_explore]:
+            try:
+                r=rule(self._config,self._tracker)
+                if r: out.extend(r)
+            except: pass
+        for n,p in self._params.items():
+            if p.prior.samples<5: continue
+            proposed=p.propose_change()
+            if abs(proposed-p.value)>=p.step*0.5:
+                out.append({"parameter":n,"old_value":p.value,"new_value":proposed,
+                            "reason":f"Bayesian: mean={p.prior.mean:.3f}, n={p.prior.samples}","source":"bayesian"})
+        return out
 
-        old_val = self._config.get(param)
-        self._config[param] = new_val
-
-        self._history.append(
-            _TuningRecord(
-                parameter=param,
-                old_value=old_val,
-                new_value=new_val,
-                reason=tuning.get("reason", ""),
-                applied_at=time.time(),
-            )
-        )
-        log.info("Applied tuning: %s %s -> %s (%s)", param, old_val, new_val, tuning.get("reason", ""))
+    def apply_tuning(self, tuning):
+        pn=tuning.get("parameter"); nv=tuning.get("new_value")
+        if not pn: return False
+        ov=self._config.get(pn); self._config[pn]=nv
+        if pn in self._params: self._params[pn].value=float(nv) if isinstance(nv,(int,float)) else nv
+        db_id=None
+        if self._storage:
+            try: db_id=self._storage.add_tuner_history(parameter=pn,old_value=ov,new_value=nv,reason=tuning.get("reason",""))
+            except: pass
+        self._history.append(_Rec(parameter=pn,old_value=ov,new_value=nv,reason=tuning.get("reason",""),applied_at=time.time(),db_id=db_id))
         return True
 
-    def revert_tuning(self, parameter: str) -> bool:
-        """Revert the most recent tuning for *parameter*."""
+    def record_param_outcome(self, param_name, success):
+        if param_name not in self._params: return
+        self._params[param_name].prior.update(success)
+        if self._storage:
+            p=self._params[param_name]
+            try: self._storage.upsert_tuner_param(param_name=param_name,value=p.value,prior=p.prior.to_dict())
+            except: pass
+
+    def revert_tuning(self, parameter):
         for rec in reversed(self._history):
-            if rec.parameter == parameter and not rec.reverted:
-                self._config[parameter] = rec.old_value
-                rec.reverted = True
-                log.info("Reverted tuning: %s back to %s", parameter, rec.old_value)
+            if rec.parameter==parameter and not rec.reverted:
+                self._config[parameter]=rec.old_value; rec.reverted=True
+                if parameter in self._params and isinstance(rec.old_value,(int,float)):
+                    self._params[parameter].value=float(rec.old_value)
+                if self._storage and rec.db_id:
+                    try: self._storage.mark_reverted(rec.db_id)
+                    except: pass
                 return True
         return False
 
-    def get_tuning_history(self) -> list[dict]:
-        """History of applied tunings and their outcomes."""
-        return [
-            {
-                "parameter": r.parameter,
-                "old_value": r.old_value,
-                "new_value": r.new_value,
-                "reason": r.reason,
-                "applied_at": r.applied_at,
-                "reverted": r.reverted,
-            }
-            for r in self._history
-        ]
+    def get_tuning_history(self):
+        return [{"parameter":r.parameter,"old_value":r.old_value,"new_value":r.new_value,
+                 "reason":r.reason,"applied_at":r.applied_at,"reverted":r.reverted} for r in self._history]
+
+    def get_param_beliefs(self):
+        return {n:{"value":p.value,"prior_mean":round(p.prior.mean,4),"prior_variance":round(p.prior.variance,6),
+                    "samples":p.prior.samples,"range":[p.min_val,p.max_val]} for n,p in self._params.items()}

--- a/src/homie_core/meta_learning/performance_tracker.py
+++ b/src/homie_core/meta_learning/performance_tracker.py
@@ -1,172 +1,75 @@
 # src/homie_core/meta_learning/performance_tracker.py
-"""Meta Performance Tracker — monitors how well Homie is improving over time."""
-
+"""Meta Performance Tracker -- strategy-aware, with SQLite persistence."""
 from __future__ import annotations
-
-import logging
-import time
-from dataclasses import dataclass, field
+import logging, time
+from dataclasses import dataclass
 from typing import Any
 
 log = logging.getLogger(__name__)
-
-_DAY_SECONDS = 86_400
-
+_DAY = 86400
 
 @dataclass
-class _TaskEntry:
-    """Single task completion record."""
-
-    task_type: str
-    timestamp: float
-    duration_ms: float
-    success: bool
-    quality_score: float
-
+class _E:
+    task_type: str; timestamp: float; duration_ms: float; success: bool
+    quality_score: float; strategy_key: str = ""; satisfaction: float = 0.0
 
 class MetaPerformanceTracker:
-    """Tracks how well Homie is improving over time."""
+    def __init__(self, storage=None):
+        self._storage, self._entries = storage, []
+        if storage:
+            try:
+                for r in storage.load_task_entries(limit=1000):
+                    self._entries.append(_E(task_type=r["task_type"], timestamp=0.0,
+                        duration_ms=r["duration_ms"], success=r["success"],
+                        quality_score=r["quality_score"], strategy_key=r.get("strategy_key",""),
+                        satisfaction=r.get("satisfaction",0.0)))
+            except: pass
 
-    def __init__(self, storage: Any | None = None):
-        self._storage = storage
-        self._entries: list[_TaskEntry] = []
+    def record_task(self, task_type, duration_ms, success, quality_score,
+                    strategy_key="", satisfaction=0.0, context=None):
+        e = _E(task_type=task_type, timestamp=time.time(), duration_ms=duration_ms,
+               success=success, quality_score=max(0.0,min(1.0,quality_score)),
+               strategy_key=strategy_key, satisfaction=max(0.0,min(1.0,satisfaction)))
+        self._entries.append(e)
+        if self._storage:
+            try: self._storage.add_task_entry(task_type=task_type, strategy_key=strategy_key, duration_ms=duration_ms, success=success, quality_score=e.quality_score, satisfaction=e.satisfaction, context=context)
+            except: pass
 
-    # ── recording ───────────────────────────────────────────────────────
+    def get_improvement_trend(self, task_type, window_days=30):
+        cutoff = time.time() - window_days*_DAY
+        rel = sorted([e for e in self._entries if e.task_type==task_type and e.timestamp>=cutoff], key=lambda e: e.timestamp)
+        if len(rel)<2: return {"task_type":task_type,"direction":"insufficient_data","improvement_rate":0.0,"confidence":0.0,"sample_size":len(rel)}
+        m=len(rel)//2; d=0.6*(_sr(rel[m:])-_sr(rel[:m]))+0.4*(_aq(rel[m:])-_aq(rel[:m]))
+        return {"task_type":task_type,"direction":"improving" if d>0.02 else ("declining" if d<-0.02 else "stable"),
+                "improvement_rate":round(d,4),"confidence":round(min(1.0,len(rel)/50),4),"sample_size":len(rel)}
 
-    def record_task(
-        self,
-        task_type: str,
-        duration_ms: float,
-        success: bool,
-        quality_score: float,
-    ) -> None:
-        """Record a task completion for trend analysis."""
-        self._entries.append(
-            _TaskEntry(
-                task_type=task_type,
-                timestamp=time.time(),
-                duration_ms=duration_ms,
-                success=success,
-                quality_score=max(0.0, min(1.0, quality_score)),
-            )
-        )
-
-    # ── analysis ────────────────────────────────────────────────────────
-
-    def get_improvement_trend(
-        self, task_type: str, window_days: int = 30
-    ) -> dict:
-        """Return trend direction, improvement rate, and confidence for *task_type*.
-
-        Splits the window into two halves and compares success rate + quality.
-        """
-        cutoff = time.time() - window_days * _DAY_SECONDS
-        relevant = [e for e in self._entries if e.task_type == task_type and e.timestamp >= cutoff]
-
-        if len(relevant) < 2:
-            return {
-                "task_type": task_type,
-                "direction": "insufficient_data",
-                "improvement_rate": 0.0,
-                "confidence": 0.0,
-                "sample_size": len(relevant),
-            }
-
-        relevant.sort(key=lambda e: e.timestamp)
-        mid = len(relevant) // 2
-        first_half = relevant[:mid]
-        second_half = relevant[mid:]
-
-        sr1 = _success_rate(first_half)
-        sr2 = _success_rate(second_half)
-        q1 = _avg_quality(first_half)
-        q2 = _avg_quality(second_half)
-
-        # Composite change (weighted 60 % success-rate, 40 % quality)
-        delta = 0.6 * (sr2 - sr1) + 0.4 * (q2 - q1)
-
-        if delta > 0.02:
-            direction = "improving"
-        elif delta < -0.02:
-            direction = "declining"
-        else:
-            direction = "stable"
-
-        confidence = min(1.0, len(relevant) / 50)
-
-        return {
-            "task_type": task_type,
-            "direction": direction,
-            "improvement_rate": round(delta, 4),
-            "confidence": round(confidence, 4),
-            "sample_size": len(relevant),
-        }
-
-    def get_bottlenecks(self) -> list[dict]:
-        """Return task types Homie is struggling with, sorted worst-first."""
-        by_type: dict[str, list[_TaskEntry]] = {}
+    def get_strategy_performance(self, task_type):
+        by = {}
         for e in self._entries:
-            by_type.setdefault(e.task_type, []).append(e)
+            if e.task_type==task_type and e.strategy_key: by.setdefault(e.strategy_key,[]).append(e)
+        return {k:{"attempts":len(v),"success_rate":round(_sr(v),4),"avg_quality":round(_aq(v),4),
+                    "avg_satisfaction":round(_asat(v),4),"avg_duration_ms":round(sum(e.duration_ms for e in v)/len(v),2)} for k,v in by.items()}
 
-        bottlenecks: list[dict] = []
-        for task_type, entries in by_type.items():
-            sr = _success_rate(entries)
-            aq = _avg_quality(entries)
-            score = 0.6 * sr + 0.4 * aq
-            if score < 0.7:
-                bottlenecks.append(
-                    {
-                        "task_type": task_type,
-                        "success_rate": round(sr, 4),
-                        "avg_quality": round(aq, 4),
-                        "composite_score": round(score, 4),
-                        "sample_size": len(entries),
-                    }
-                )
+    def get_best_strategy(self, task_type):
+        p=self.get_strategy_performance(task_type)
+        return max(p,key=lambda k:0.4*p[k]["success_rate"]+0.35*p[k]["avg_quality"]+0.25*p[k]["avg_satisfaction"]) if p else None
 
-        bottlenecks.sort(key=lambda b: b["composite_score"])
-        return bottlenecks
+    def get_bottlenecks(self):
+        by={}
+        for e in self._entries: by.setdefault(e.task_type,[]).append(e)
+        bn=[]
+        for tt,ents in by.items():
+            sr,aq=_sr(ents),_aq(ents); sc=0.6*sr+0.4*aq
+            if sc<0.7: bn.append({"task_type":tt,"success_rate":round(sr,4),"avg_quality":round(aq,4),"composite_score":round(sc,4),"sample_size":len(ents),"best_strategy":self.get_best_strategy(tt)})
+        bn.sort(key=lambda b:b["composite_score"]); return bn
 
-    def get_overall_health(self) -> dict:
-        """Overall system health and improvement metrics."""
-        if not self._entries:
-            return {
-                "status": "no_data",
-                "total_tasks": 0,
-                "overall_success_rate": 0.0,
-                "overall_avg_quality": 0.0,
-                "bottleneck_count": 0,
-            }
+    def get_overall_health(self):
+        if not self._entries: return {"status":"no_data","total_tasks":0,"overall_success_rate":0.0,"overall_avg_quality":0.0,"bottleneck_count":0}
+        sr,aq=_sr(self._entries),_aq(self._entries)
+        st="healthy" if sr>=0.9 and aq>=0.8 else ("fair" if sr>=0.7 else "needs_attention")
+        return {"status":st,"total_tasks":len(self._entries),"overall_success_rate":round(sr,4),"overall_avg_quality":round(aq,4),"bottleneck_count":len(self.get_bottlenecks())}
 
-        sr = _success_rate(self._entries)
-        aq = _avg_quality(self._entries)
-        bottlenecks = self.get_bottlenecks()
-
-        if sr >= 0.9 and aq >= 0.8:
-            status = "healthy"
-        elif sr >= 0.7:
-            status = "fair"
-        else:
-            status = "needs_attention"
-
-        return {
-            "status": status,
-            "total_tasks": len(self._entries),
-            "overall_success_rate": round(sr, 4),
-            "overall_avg_quality": round(aq, 4),
-            "bottleneck_count": len(bottlenecks),
-        }
-
-
-# ── helpers ─────────────────────────────────────────────────────────────
-
-def _success_rate(entries: list[_TaskEntry]) -> float:
-    if not entries:
-        return 0.0
-    return sum(1 for e in entries if e.success) / len(entries)
-
-
-def _avg_quality(entries: list[_TaskEntry]) -> float:
-    if not entries:
-        return 0.0
-    return sum(e.quality_score for e in entries) / len(entries)
+def _sr(e): return sum(1 for x in e if x.success)/len(e) if e else 0.0
+def _aq(e): return sum(x.quality_score for x in e)/len(e) if e else 0.0
+def _asat(e):
+    v=[x.satisfaction for x in e if x.satisfaction>0]; return sum(v)/len(v) if v else 0.0

--- a/src/homie_core/meta_learning/persistence.py
+++ b/src/homie_core/meta_learning/persistence.py
@@ -1,0 +1,84 @@
+# src/homie_core/meta_learning/persistence.py
+"""SQLite persistence layer for meta-learning state."""
+from __future__ import annotations
+import json, logging, sqlite3
+from pathlib import Path
+from typing import Any
+from homie_core.utils import utc_now
+
+log = logging.getLogger(__name__)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS ml_strategy_records (task_type TEXT NOT NULL, strategy_key TEXT NOT NULL, attempts INTEGER NOT NULL DEFAULT 0, successes INTEGER NOT NULL DEFAULT 0, total_duration_ms REAL NOT NULL DEFAULT 0.0, total_quality REAL NOT NULL DEFAULT 0.0, total_satisfaction REAL NOT NULL DEFAULT 0.0, last_used TEXT NOT NULL, updated_at TEXT NOT NULL, PRIMARY KEY (task_type, strategy_key));
+CREATE TABLE IF NOT EXISTS ml_strategy_registry (task_type TEXT NOT NULL, strategy_key TEXT NOT NULL, strategy_json TEXT NOT NULL, updated_at TEXT NOT NULL, PRIMARY KEY (task_type, strategy_key));
+CREATE TABLE IF NOT EXISTS ml_tuner_params (param_name TEXT PRIMARY KEY, value_json TEXT NOT NULL, prior_json TEXT NOT NULL DEFAULT '{}', updated_at TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS ml_tuner_history (id INTEGER PRIMARY KEY AUTOINCREMENT, parameter TEXT NOT NULL, old_value TEXT NOT NULL, new_value TEXT NOT NULL, reason TEXT NOT NULL DEFAULT '', applied_at TEXT NOT NULL, reverted INTEGER NOT NULL DEFAULT 0);
+CREATE TABLE IF NOT EXISTS ml_task_entries (id INTEGER PRIMARY KEY AUTOINCREMENT, task_type TEXT NOT NULL, strategy_key TEXT NOT NULL DEFAULT '', timestamp TEXT NOT NULL, duration_ms REAL NOT NULL, success INTEGER NOT NULL, quality_score REAL NOT NULL, satisfaction REAL NOT NULL DEFAULT 0.0, context_json TEXT NOT NULL DEFAULT '{}');
+"""
+
+class MetaLearningStore:
+    def __init__(self, db_path: Path | str):
+        self._path = Path(db_path)
+        self._conn: sqlite3.Connection | None = None
+
+    def initialize(self):
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._path))
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+    def close(self):
+        if self._conn: self._conn.close(); self._conn = None
+
+    @property
+    def conn(self):
+        if self._conn is None: raise RuntimeError("MetaLearningStore not initialised")
+        return self._conn
+
+    def upsert_strategy_record(self, task_type, strategy_key, attempts, successes, total_duration_ms, total_quality, total_satisfaction, last_used):
+        now = utc_now().isoformat()
+        self.conn.execute("INSERT INTO ml_strategy_records (task_type, strategy_key, attempts, successes, total_duration_ms, total_quality, total_satisfaction, last_used, updated_at) VALUES (?,?,?,?,?,?,?,?,?) ON CONFLICT(task_type, strategy_key) DO UPDATE SET attempts=excluded.attempts, successes=excluded.successes, total_duration_ms=excluded.total_duration_ms, total_quality=excluded.total_quality, total_satisfaction=excluded.total_satisfaction, last_used=excluded.last_used, updated_at=excluded.updated_at", (task_type, strategy_key, attempts, successes, total_duration_ms, total_quality, total_satisfaction, last_used, now))
+        self.conn.commit()
+
+    def load_strategy_records(self): return [dict(r) for r in self.conn.execute("SELECT * FROM ml_strategy_records").fetchall()]
+
+    def upsert_strategy(self, task_type, strategy_key, strategy):
+        now = utc_now().isoformat()
+        self.conn.execute("INSERT INTO ml_strategy_registry (task_type, strategy_key, strategy_json, updated_at) VALUES (?,?,?,?) ON CONFLICT(task_type, strategy_key) DO UPDATE SET strategy_json=excluded.strategy_json, updated_at=excluded.updated_at", (task_type, strategy_key, json.dumps(strategy), now))
+        self.conn.commit()
+
+    def load_strategies(self):
+        return [{**dict(r), "strategy": json.loads(r["strategy_json"])} for r in self.conn.execute("SELECT * FROM ml_strategy_registry").fetchall()]
+
+    def upsert_tuner_param(self, param_name, value, prior=None):
+        now = utc_now().isoformat()
+        self.conn.execute("INSERT INTO ml_tuner_params (param_name, value_json, prior_json, updated_at) VALUES (?,?,?,?) ON CONFLICT(param_name) DO UPDATE SET value_json=excluded.value_json, prior_json=excluded.prior_json, updated_at=excluded.updated_at", (param_name, json.dumps(value), json.dumps(prior or {}), now))
+        self.conn.commit()
+
+    def load_tuner_params(self):
+        return {r["param_name"]: {"value": json.loads(r["value_json"]), "prior": json.loads(r["prior_json"])} for r in self.conn.execute("SELECT * FROM ml_tuner_params").fetchall()}
+
+    def add_tuner_history(self, parameter, old_value, new_value, reason):
+        now = utc_now().isoformat()
+        cur = self.conn.execute("INSERT INTO ml_tuner_history (parameter, old_value, new_value, reason, applied_at) VALUES (?,?,?,?,?)", (parameter, json.dumps(old_value), json.dumps(new_value), reason, now))
+        self.conn.commit()
+        return cur.lastrowid
+
+    def mark_reverted(self, row_id):
+        self.conn.execute("UPDATE ml_tuner_history SET reverted=1 WHERE id=?", (row_id,)); self.conn.commit()
+
+    def load_tuner_history(self):
+        return [{**dict(r), "old_value": json.loads(r["old_value"]), "new_value": json.loads(r["new_value"])} for r in self.conn.execute("SELECT * FROM ml_tuner_history ORDER BY applied_at DESC").fetchall()]
+
+    def add_task_entry(self, task_type, strategy_key, duration_ms, success, quality_score, satisfaction=0.0, context=None):
+        now = utc_now().isoformat()
+        cur = self.conn.execute("INSERT INTO ml_task_entries (task_type, strategy_key, timestamp, duration_ms, success, quality_score, satisfaction, context_json) VALUES (?,?,?,?,?,?,?,?)", (task_type, strategy_key, now, duration_ms, int(success), quality_score, satisfaction, json.dumps(context or {})))
+        self.conn.commit()
+        return cur.lastrowid
+
+    def load_task_entries(self, task_type=None, limit=500):
+        if task_type: rows = self.conn.execute("SELECT * FROM ml_task_entries WHERE task_type=? ORDER BY timestamp DESC LIMIT ?", (task_type, limit)).fetchall()
+        else: rows = self.conn.execute("SELECT * FROM ml_task_entries ORDER BY timestamp DESC LIMIT ?", (limit,)).fetchall()
+        return [{**dict(r), "success": bool(r["success"]), "context": json.loads(r["context_json"])} for r in rows]

--- a/src/homie_core/meta_learning/strategies.py
+++ b/src/homie_core/meta_learning/strategies.py
@@ -1,0 +1,83 @@
+# src/homie_core/meta_learning/strategies.py
+"""Concrete reasoning strategies: DirectPrompt, ChainOfThought, ToolAugmented."""
+from __future__ import annotations
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+class ReasoningStrategy(ABC):
+    @property
+    @abstractmethod
+    def name(self) -> str: ...
+    @property
+    @abstractmethod
+    def cost_estimate(self) -> float: ...
+    @abstractmethod
+    def apply(self, query: str, context: dict[str, Any]) -> dict[str, Any]: ...
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "planning": self.name, "cost_estimate": self.cost_estimate, "agents": [], "tools": []}
+
+
+class DirectPromptStrategy(ReasoningStrategy):
+    @property
+    def name(self): return "direct_prompt"
+    @property
+    def cost_estimate(self): return 0.1
+    def apply(self, query, context):
+        return {"guidance": "Answer directly and concisely.", "context_budget_factor": 0.6, "planning": "reactive", "tools": []}
+    def to_dict(self):
+        return {"name": self.name, "planning": "reactive", "cost_estimate": self.cost_estimate, "agents": ["conversationalist"], "tools": []}
+
+
+class ChainOfThoughtStrategy(ReasoningStrategy):
+    @property
+    def name(self): return "chain_of_thought"
+    @property
+    def cost_estimate(self): return 0.5
+    def apply(self, query, context):
+        complexity = context.get("complexity", "moderate")
+        if complexity in ("complex", "deep"):
+            guidance = ("Think step by step: 1) Identify the core question. "
+                        "2) List relevant facts. 3) Reason through possibilities. "
+                        "4) Synthesise a clear answer. Show reasoning before conclusion.")
+            return {"guidance": guidance, "context_budget_factor": 1.0, "max_tokens_factor": 1.5,
+                    "temperature": 0.5, "planning": "chain_of_thought", "tools": []}
+        return {"guidance": "Think briefly step by step before answering.",
+                "context_budget_factor": 1.0, "max_tokens_factor": 1.2,
+                "temperature": 0.5, "planning": "chain_of_thought", "tools": []}
+    def to_dict(self):
+        return {"name": self.name, "planning": "chain_of_thought", "cost_estimate": self.cost_estimate, "agents": ["reasoner"], "tools": []}
+
+
+class ToolAugmentedStrategy(ReasoningStrategy):
+    def __init__(self, available_tools=None):
+        self._available_tools = available_tools or ["web_search", "rag", "editor", "calculator"]
+    @property
+    def name(self): return "tool_augmented"
+    @property
+    def cost_estimate(self): return 0.9
+    def apply(self, query, context):
+        selected, q = [], query.lower()
+        if any(kw in q for kw in ("search", "find", "latest", "news")): selected.append("web_search")
+        if any(kw in q for kw in ("document", "file", "pdf", "article")): selected.append("rag")
+        if any(kw in q for kw in ("code", "script", "function", "debug")): selected.append("editor")
+        if any(kw in q for kw in ("calculate", "compute", "math")): selected.append("calculator")
+        if not selected: selected = ["web_search", "rag"]
+        selected = [t for t in selected if t in self._available_tools]
+        return {"guidance": f"Use available tools: {', '.join(selected)}. Cite tool results.",
+                "context_budget_factor": 1.3, "max_tokens_factor": 1.5,
+                "temperature": 0.6, "planning": "tool_augmented", "tools": selected}
+    def to_dict(self):
+        return {"name": self.name, "planning": "tool_augmented", "cost_estimate": self.cost_estimate,
+                "agents": ["researcher"], "tools": list(self._available_tools)}
+
+
+BUILTIN_STRATEGIES: list[ReasoningStrategy] = [DirectPromptStrategy(), ChainOfThoughtStrategy(), ToolAugmentedStrategy()]
+
+def get_strategy_by_name(name: str) -> ReasoningStrategy | None:
+    for s in BUILTIN_STRATEGIES:
+        if s.name == name: return s
+    return None

--- a/src/homie_core/meta_learning/strategy_selector.py
+++ b/src/homie_core/meta_learning/strategy_selector.py
@@ -1,18 +1,54 @@
 # src/homie_core/meta_learning/strategy_selector.py
-"""Strategy Selector — learns which strategies work best for different task types."""
-
+"""Strategy Selector -- epsilon-greedy and UCB1 multi-armed bandits."""
 from __future__ import annotations
-
-import logging
-import random
-import time
-from dataclasses import dataclass, field
+import logging, math, random, time
+from dataclasses import dataclass
+from enum import Enum
 from typing import Any
+from .strategies import BUILTIN_STRATEGIES, ReasoningStrategy, get_strategy_by_name
 
 log = logging.getLogger(__name__)
+EXPLORE_RATE = 0.15
 
-# ── default strategies per broad task category ──────────────────────────
-_DEFAULT_STRATEGIES: dict[str, list[dict]] = {
+
+@dataclass
+class ArmRecord:
+    attempts: int = 0; successes: int = 0
+    total_duration_ms: float = 0.0; total_quality: float = 0.0
+    total_satisfaction: float = 0.0; last_used: float = 0.0
+
+    @property
+    def success_rate(self): return self.successes / self.attempts if self.attempts else 0.0
+    @property
+    def avg_quality(self): return self.total_quality / self.attempts if self.attempts else 0.0
+    @property
+    def avg_satisfaction(self): return self.total_satisfaction / self.attempts if self.attempts else 0.0
+    @property
+    def avg_duration_ms(self): return self.total_duration_ms / self.attempts if self.attempts else 0.0
+    def reward(self): return 0.40*self.success_rate + 0.35*self.avg_quality + 0.25*self.avg_satisfaction
+
+
+class SelectionAlgorithm(str, Enum):
+    EPSILON_GREEDY = "epsilon_greedy"
+    UCB1 = "ucb1"
+
+
+def _eps_select(arms, eps):
+    keys = list(arms.keys())
+    if not keys: raise ValueError("No arms")
+    return random.choice(keys) if random.random() < eps else max(keys, key=lambda k: arms[k].reward())
+
+
+def _ucb1_select(arms):
+    keys = list(arms.keys())
+    if not keys: raise ValueError("No arms")
+    total = sum(a.attempts for a in arms.values())
+    untried = [k for k in keys if arms[k].attempts == 0]
+    if untried: return random.choice(untried)
+    return max(keys, key=lambda k: arms[k].reward() + math.sqrt(2.0*math.log(total)/arms[k].attempts))
+
+
+_DEFAULT_STRATEGIES = {
     "code_generation": [
         {"agents": ["coder"], "planning": "chain_of_thought", "tools": ["editor"]},
         {"agents": ["coder", "reviewer"], "planning": "plan_and_execute", "tools": ["editor", "linter"]},
@@ -21,140 +57,82 @@ _DEFAULT_STRATEGIES: dict[str, list[dict]] = {
         {"agents": ["researcher"], "planning": "breadth_first", "tools": ["web_search"]},
         {"agents": ["researcher", "summariser"], "planning": "iterative_deepening", "tools": ["web_search", "rag"]},
     ],
-    "conversation": [
-        {"agents": ["conversationalist"], "planning": "reactive", "tools": []},
-    ],
+    "conversation": [{"agents": ["conversationalist"], "planning": "reactive", "tools": []}],
 }
 
-EXPLORE_RATE = 0.15  # epsilon for epsilon-greedy exploration
 
-
-@dataclass
-class _StrategyRecord:
-    """Accumulated performance data for one (task_type, strategy_key) pair."""
-
-    attempts: int = 0
-    successes: int = 0
-    total_duration_ms: float = 0.0
-    total_quality: float = 0.0
-    last_used: float = 0.0
-
-    @property
-    def success_rate(self) -> float:
-        return self.successes / self.attempts if self.attempts else 0.0
-
-    @property
-    def avg_duration_ms(self) -> float:
-        return self.total_duration_ms / self.attempts if self.attempts else 0.0
-
-    @property
-    def avg_quality(self) -> float:
-        return self.total_quality / self.attempts if self.attempts else 0.0
-
-    def score(self) -> float:
-        """Composite score used for ranking (higher is better)."""
-        return 0.6 * self.success_rate + 0.4 * self.avg_quality
-
-
-def _strategy_key(strategy: dict) -> str:
-    """Deterministic string key for a strategy dict."""
-    agents = ",".join(sorted(strategy.get("agents", [])))
-    planning = strategy.get("planning", "")
-    tools = ",".join(sorted(strategy.get("tools", [])))
-    return f"{agents}|{planning}|{tools}"
+def _skey(s):
+    if isinstance(s, ReasoningStrategy): return s.name
+    return f"{','.join(sorted(s.get('agents',[])))}" + f"|{s.get('planning',s.get('name',''))}" + f"|{','.join(sorted(s.get('tools',[])))}"
 
 
 class StrategySelector:
-    """Learns which strategies work best for different task types."""
+    """Bandit-based strategy selector with SQLite persistence."""
 
-    def __init__(self, storage: Any | None = None, explore_rate: float = EXPLORE_RATE):
-        self._storage = storage
-        self._explore_rate = explore_rate
-        # {task_type: {strategy_key: _StrategyRecord}}
-        self._records: dict[str, dict[str, _StrategyRecord]] = {}
-        # {task_type: {strategy_key: strategy_dict}}
+    def __init__(self, storage=None, explore_rate=EXPLORE_RATE, algorithm=SelectionAlgorithm.UCB1):
+        self._storage, self._explore_rate, self._algorithm = storage, explore_rate, algorithm
+        self._records: dict[str, dict[str, ArmRecord]] = {}
         self._strategies: dict[str, dict[str, dict]] = {}
-        self._load_defaults()
+        self._reasoning: dict[str, ReasoningStrategy] = {}
+        for tt, strats in _DEFAULT_STRATEGIES.items():
+            for s in strats: self._strategies.setdefault(tt, {})[_skey(s)] = s
+        for s in BUILTIN_STRATEGIES:
+            self._reasoning[s.name] = s
+            for tt in ("conversation","code_generation","research","general","analysis","creative"):
+                self._strategies.setdefault(tt, {})[_skey(s)] = s.to_dict()
+        if storage:
+            try:
+                for r in storage.load_strategies():
+                    self._strategies.setdefault(r["task_type"], {})[r["strategy_key"]] = r["strategy"]
+                for r in storage.load_strategy_records():
+                    self._records.setdefault(r["task_type"], {})[r["strategy_key"]] = ArmRecord(
+                        attempts=r["attempts"], successes=r["successes"],
+                        total_duration_ms=r["total_duration_ms"], total_quality=r["total_quality"],
+                        total_satisfaction=r.get("total_satisfaction", 0.0))
+            except Exception: log.warning("Failed to load meta-learning state", exc_info=True)
 
-    # ── public API ──────────────────────────────────────────────────────
+    def select_strategy(self, task_type, context=None):
+        cands = self._strategies.get(task_type, {})
+        if not cands: return {"agents": [], "planning": "reactive", "tools": []}
+        arm_map = self._records.setdefault(task_type, {})
+        for k in cands: arm_map.setdefault(k, ArmRecord())
+        chosen = _eps_select(arm_map, self._explore_rate) if self._algorithm == SelectionAlgorithm.EPSILON_GREEDY else _ucb1_select(arm_map)
+        return dict(cands[chosen])
 
-    def select_strategy(self, task_type: str, context: dict | None = None) -> dict:
-        """Select optimal strategy using epsilon-greedy over historical data."""
-        context = context or {}
-        candidates = self._strategies.get(task_type, {})
+    def select_reasoning_strategy(self, task_type, context=None):
+        sel = self.select_strategy(task_type, context)
+        name = sel.get("planning") or sel.get("name", "")
+        return self._reasoning.get(name) or self._reasoning.get(_skey(sel))
 
-        if not candidates:
-            log.info("No strategies registered for %s — returning empty.", task_type)
-            return {"agents": [], "planning": "reactive", "tools": []}
+    def record_outcome(self, task_type, strategy, success, metrics=None):
+        metrics = metrics or {}; key = _skey(strategy)
+        arm = self._records.setdefault(task_type, {}).setdefault(key, ArmRecord())
+        arm.attempts += 1
+        if success: arm.successes += 1
+        arm.total_duration_ms += metrics.get("duration_ms", 0.0)
+        arm.total_quality += metrics.get("quality", 0.0)
+        arm.total_satisfaction += metrics.get("satisfaction", 0.0)
+        arm.last_used = time.time()
+        self._strategies.setdefault(task_type, {})[key] = strategy.to_dict() if isinstance(strategy, ReasoningStrategy) else strategy
+        if self._storage:
+            try: self._storage.upsert_strategy_record(task_type=task_type, strategy_key=key, attempts=arm.attempts, successes=arm.successes, total_duration_ms=arm.total_duration_ms, total_quality=arm.total_quality, total_satisfaction=arm.total_satisfaction, last_used=str(arm.last_used))
+            except: pass
 
-        # Explore: pick randomly
-        if random.random() < self._explore_rate:
-            key = random.choice(list(candidates.keys()))
-            log.debug("Exploring strategy %s for %s", key, task_type)
-            return dict(candidates[key])
+    def get_strategy_stats(self, task_type):
+        return {k: {"attempts": r.attempts, "success_rate": round(r.success_rate,4), "avg_duration_ms": round(r.avg_duration_ms,2), "avg_quality": round(r.avg_quality,4), "avg_satisfaction": round(r.avg_satisfaction,4), "reward": round(r.reward(),4)} for k,r in self._records.get(task_type,{}).items()}
 
-        # Exploit: pick the highest-scoring strategy
-        best_key, best_score = None, -1.0
-        for key in candidates:
-            record = self._records.get(task_type, {}).get(key)
-            score = record.score() if record else 0.0
-            if score > best_score:
-                best_score = score
-                best_key = key
+    def register_strategy(self, task_type, strategy):
+        key = _skey(strategy)
+        if isinstance(strategy, ReasoningStrategy):
+            self._strategies.setdefault(task_type, {})[key] = strategy.to_dict()
+            self._reasoning[key] = strategy
+        else: self._strategies.setdefault(task_type, {})[key] = strategy
 
-        chosen = candidates[best_key]  # type: ignore[index]
-        log.debug("Selected strategy %s (score=%.3f) for %s", best_key, best_score, task_type)
-        return dict(chosen)
-
-    def record_outcome(
-        self,
-        task_type: str,
-        strategy: dict,
-        success: bool,
-        metrics: dict | None = None,
-    ) -> None:
-        """Record how well a strategy worked."""
-        metrics = metrics or {}
-        key = _strategy_key(strategy)
-
-        if task_type not in self._records:
-            self._records[task_type] = {}
-        if key not in self._records[task_type]:
-            self._records[task_type][key] = _StrategyRecord()
-
-        rec = self._records[task_type][key]
-        rec.attempts += 1
-        if success:
-            rec.successes += 1
-        rec.total_duration_ms += metrics.get("duration_ms", 0.0)
-        rec.total_quality += metrics.get("quality", 0.0)
-        rec.last_used = time.time()
-
-        # Ensure strategy is registered
-        self._strategies.setdefault(task_type, {})[key] = strategy
-
-    def get_strategy_stats(self, task_type: str) -> dict:
-        """Get performance stats per strategy for a task type."""
-        records = self._records.get(task_type, {})
-        return {
-            key: {
-                "attempts": r.attempts,
-                "success_rate": round(r.success_rate, 4),
-                "avg_duration_ms": round(r.avg_duration_ms, 2),
-                "avg_quality": round(r.avg_quality, 4),
-                "score": round(r.score(), 4),
-            }
-            for key, r in records.items()
-        }
-
-    def register_strategy(self, task_type: str, strategy: dict) -> None:
-        """Register a new strategy for a task type."""
-        key = _strategy_key(strategy)
-        self._strategies.setdefault(task_type, {})[key] = strategy
-
-    # ── internals ───────────────────────────────────────────────────────
-
-    def _load_defaults(self) -> None:
-        for task_type, strategies in _DEFAULT_STRATEGIES.items():
-            for s in strategies:
-                self.register_strategy(task_type, s)
+    @property
+    def algorithm(self): return self._algorithm
+    @algorithm.setter
+    def algorithm(self, v): self._algorithm = v
+    @property
+    def explore_rate(self): return self._explore_rate
+    @explore_rate.setter
+    def explore_rate(self, v): self._explore_rate = max(0.0, min(1.0, v))


### PR DESCRIPTION
## Summary
- **Epsilon-greedy and UCB1 multi-armed bandit** strategy selectors that learn which reasoning approach works best per query type
- **3 concrete reasoning strategies**: DirectPrompt (fast, minimal), ChainOfThought (step-by-step reasoning), ToolAugmented (plugin-assisted research)
- **Bayesian-inspired auto-tuner** with Beta-distribution priors for hyperparameters (temperature, max_tokens, context_budget, explore_rate)
- **Strategy performance tracking** with success rate, latency, quality score, and user satisfaction signals
- **SQLite persistence** (MetaLearningStore) so all learned state survives restarts
- **Brain integration**: meta-learning wired into CogArc's REASON stage to dynamically select strategies and tune generation parameters

## Files changed/created
- `src/homie_core/meta_learning/strategies.py` (NEW) - ReasoningStrategy ABC + 3 concrete strategies
- `src/homie_core/meta_learning/persistence.py` (NEW) - MetaLearningStore SQLite layer
- `src/homie_core/meta_learning/strategy_selector.py` - Rewrote with UCB1/epsilon-greedy bandits
- `src/homie_core/meta_learning/auto_tuner.py` - Added BetaPrior Thompson sampling
- `src/homie_core/meta_learning/performance_tracker.py` - Added strategy-level tracking
- `src/homie_core/meta_learning/__init__.py` - Updated exports
- `src/homie_core/brain/cognitive_arch.py` - Wired meta-learning into REASON stage

## Test plan
- [ ] Verify StrategySelector selects strategies via UCB1 and epsilon-greedy
- [ ] Verify BetaPrior updates correctly and Thompson sampling proposes changes
- [ ] Verify MetaLearningStore persists and loads all tables correctly
- [ ] Verify CognitiveArchitecture falls back gracefully when meta-learning is unavailable
- [ ] Verify strategy performance recording flows through to SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)